### PR TITLE
리액트 11일차 - key 속성, 선택한 연도의 리스트 표출, 조건부 내용 출력

### DIFF
--- a/리액트 복습/App.js
+++ b/리액트 복습/App.js
@@ -7,7 +7,7 @@ import ExpenseListFilter from "./components/ExpenseListFilter";
 import "./App.css";
 
 const expensesDummy = [
-  {id: 'ex1', itemName: '커피', price: 9500, date: new Date('2020-01-26')},
+  {id: 'ex1', itemName: '커피', price: 9500, date: new Date('2021-01-26')},
   {id: 'ex2', itemName: '스피커', price: 106000, date: new Date('2021-04-16')},
   {id: 'ex3', itemName: '로션', price: 12000, date: new Date('2022-07-05')},
   {id: 'ex4', itemName: '컴퓨터부품', price: 3300000, date: new Date('2023-02-20')}
@@ -28,13 +28,17 @@ const App = () => {
     setSelectedYear(userYear);
   }
 
+  const filterExpenseList = expense.filter((ExpenseFilter) => {
+    return ExpenseFilter.date.getFullYear().toString() === selectedYear;
+})
+
   return (
     <div className="App">
       <ExpenseHeader />
       <ExpenseUser onAddList={addExpenseListHandler} />
       <ExpenseMainTitle />
       <ExpenseListFilter selectYear={selectedYear} onFilterChange={filterHandler} />
-      <ExpenseExampleData item={expense} />
+      <ExpenseExampleData item={expense} onFilterExpenseList={filterExpenseList} />
     </div>
   );
 }

--- a/리액트 복습/ExpenseExampleData.css
+++ b/리액트 복습/ExpenseExampleData.css
@@ -1,0 +1,15 @@
+.main_expanselist_data {
+    margin: auto;
+    margin-top: 30px;
+    background-color: #414141;
+    width: 40%;
+    border-radius: 8px;
+    padding: .5rem 1rem;
+    box-shadow: 0 3px 5px #3a3a3a;
+}
+
+.main_expanselist_data p {
+    text-align: center;
+    color: var(--color-font-1);
+    font-size: 1.5rem;
+}

--- a/리액트 복습/ExpenseUser.css
+++ b/리액트 복습/ExpenseUser.css
@@ -1,5 +1,20 @@
+button {
+    background-color: var(--color-box-3);
+    padding: .5rem 1.5rem;
+    margin: 20px auto;
+    font-size: 1.5rem;
+    color: var(--color-font-1);
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: var(--color-box-1);
+}
+
 .main_userdata {
     margin-bottom: 20px;
+    text-align: center;
 }
 
 .main_userdata h2 {

--- a/리액트 복습/ExpenseUser.js
+++ b/리액트 복습/ExpenseUser.js
@@ -1,7 +1,10 @@
+import React, {useState} from "react";
 import ExpenseUserForm from "./ExpenseUserForm";
 import "./ExpenseUser.css";
 
 const ExpenseUser = (props) => {
+    const [expenseDisplay, setExpenseDisplay] = useState(false);
+
     const userFormDataHandler = (formData) => {
         const userFormData = {
             ...formData, 
@@ -10,10 +13,19 @@ const ExpenseUser = (props) => {
         props.onAddList(userFormData);
     }
 
+    const expenseDisplayHandler = () => {
+        setExpenseDisplay(true);
+    }
+
+    const formCancelHandler = () => {
+        setExpenseDisplay(false);
+    }
+
     return (
         <div className="main_userdata">
             <h2>지출 추가하기</h2>
-            <ExpenseUserForm onUserFormData={userFormDataHandler} />
+            {!expenseDisplay && <button onClick={expenseDisplayHandler} type="button">지출을 추가하려면 여기를 클릭하세요</button>}
+            {expenseDisplay && <ExpenseUserForm onUserFormData={userFormDataHandler} onCancel={formCancelHandler} />}
         </div>
     );
 }

--- a/리액트 복습/ExpenseUserForm.css
+++ b/리액트 복습/ExpenseUserForm.css
@@ -25,7 +25,20 @@ input {
     cursor: pointer;
 }
 
-#form_btn:hover {
+#form_cancel_btn {
+    margin-left: 20px;
+    margin-top: 20px;
+    background-color: var(--color-box-1);
+    padding: .8rem 1.5rem;
+    font-size: 1.2rem;
+    color: var(--color-font-1);
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+}
+
+#form_btn:hover,
+#form_cancel_btn:hover {
     background-color: var(--color-box-3);
 }
 

--- a/리액트 복습/ExpenseUserForm.js
+++ b/리액트 복습/ExpenseUserForm.js
@@ -43,7 +43,10 @@ const ExpenseUserForm = (props) => {
                 <input onChange={priceChangeHandler} type="number" name="price" id="user_item_price" min="100" step="100" value={priceChange} required />
                 <label for="user_expense_date">구입날짜</label>
                 <input onChange={dateChangeHandler} type="date" name="expenseDate" id="user_expense_date" min="2020-01-01" max="2023-12-31" value={dateChange} required />
-                <button id="form_btn" type="submit">리스트에 추가하기</button>
+                <div className="form_btn_box">
+                    <button id="form_btn" type="submit">리스트에 추가하기</button>
+                    <button onClick={props.onCancel} id="form_cancel_btn" type="button">닫기</button>
+                </div>
             </div>
         </form>
     );

--- a/리액트 복습/ExpensesExampleData.js
+++ b/리액트 복습/ExpensesExampleData.js
@@ -2,13 +2,24 @@ import ExpenseItem from "./ExpenseItem";
 import "./ExpenseExampleData.css";
 
 const ExpenseExampleData = (props) => {
-    return (
-        <div className="main_expanselist_data">
-            {props.item.map((expensesExample) => 
-                <ExpenseItem itemName={expensesExample.itemName} price={expensesExample.price} date={expensesExample.date} />
-            )}
-        </div>
-    );
-}
+  let expenseListMsg = <p>해당 연도의 지출내역이 없습니다.</p>;
+
+  if (props.onFilterExpenseList.length > 0) {
+        expenseListMsg = props.onFilterExpenseList.map((expensesExample) => (
+            <ExpenseItem
+                key={expensesExample.id}
+                itemName={expensesExample.itemName}
+                price={expensesExample.price}
+                date={expensesExample.date}
+            />
+        )); 
+  }
+
+  return (
+    <div className="main_expanselist_data">
+      {expenseListMsg}
+    </div>
+  );
+};
 
 export default ExpenseExampleData;


### PR DESCRIPTION
<웹페이지 변경사항>
🔎 key속성을 사용하여 배열 내 데이터에 고유 id를 부여해주어 웹페이지 안정성을 높였습니다. 🔎 사용자가 선택한 연도에 해당하는 지출리스트만 표출하도록 수정해주었습니다.
🔎 사용자가 원할 때 버튼을 눌러 지출내역을 추가할 수 있도록 변경했습니다. 또, 사용자가 새 데이터를 추가하면 지출내역 입력양식을 닫을 수 있도록 해주었습니다. 🔎 관련 포스팅: https://itinfogarage.tistory.com/73