### PR TITLE
리액트 13일차 - 리액트 컴포넌트에 css 스타일링하는 여러 방법

### DIFF
--- a/리액트 파일의 CSS 스타일링/App.css
+++ b/리액트 파일의 CSS 스타일링/App.css
@@ -1,0 +1,14 @@
+#goals {
+  width: 35rem;
+  max-width: 90%;
+  margin: 3rem auto;
+}
+
+#goal-form {
+  width: 30rem;
+  max-width: 90%;
+  margin: 3rem auto;
+  padding: 2rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+}

--- a/리액트 파일의 CSS 스타일링/App.js
+++ b/리액트 파일의 CSS 스타일링/App.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+import CourseGoalList from './components/CourseGoals/CourseGoalList/CourseGoalList';
+import CourseInput from './components/CourseGoals/CourseInput/CourseInput';
+import './App.css';
+
+const App = () => {
+  const [courseGoals, setCourseGoals] = useState([
+    { text: 'Do all exercises!', id: 'g1' },
+    { text: 'Finish the course!', id: 'g2' }
+  ]);
+
+  const addGoalHandler = enteredText => {
+    setCourseGoals(prevGoals => {
+      const updatedGoals = [...prevGoals];
+      updatedGoals.unshift({ text: enteredText, id: Math.random().toString() });
+      return updatedGoals;
+    });
+  };
+
+  const deleteItemHandler = goalId => {
+    setCourseGoals(prevGoals => {
+      const updatedGoals = prevGoals.filter(goal => goal.id !== goalId);
+      return updatedGoals;
+    });
+  };
+
+  let content = (
+    <p style={{ textAlign: 'center' }}>No goals found. Maybe add one?</p>
+  );
+
+  if (courseGoals.length > 0) {
+    content = (
+      <CourseGoalList items={courseGoals} onDeleteItem={deleteItemHandler} />
+    );
+  }
+
+  return (
+    <div>
+      <section id="goal-form">
+        <CourseInput onAddGoal={addGoalHandler} />
+      </section>
+      <section id="goals">
+        {content}
+        {/* {courseGoals.length > 0 && (
+          <CourseGoalList
+            items={courseGoals}
+            onDeleteItem={deleteItemHandler}
+          />
+        ) // <p style={{ textAlign: 'center' }}>No goals found. Maybe add one?</p>
+        } */}
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalItem/CourseGoalItem.css
+++ b/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalItem/CourseGoalItem.css
@@ -1,0 +1,8 @@
+.goal-item {
+  margin: 1rem 0;
+  background: #8b005d;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.26);
+  color: white;
+  padding: 1rem 2rem;
+  cursor: pointer;
+}

--- a/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalItem/CourseGoalItem.js
+++ b/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalItem/CourseGoalItem.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import './CourseGoalItem.css';
+
+const CourseGoalItem = props => {
+  // const [deleteText, setDeleteText] = useState('');
+
+  const deleteHandler = () => {
+    // setDeleteText('(Deleted!)');
+    props.onDelete(props.id);
+  };
+
+  return (
+    <li className="goal-item" onClick={deleteHandler}>
+      {props.children}
+    </li>
+  );
+};
+
+export default CourseGoalItem;

--- a/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalList/CourseGoalList.css
+++ b/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalList/CourseGoalList.css
@@ -1,0 +1,5 @@
+.goal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalList/CourseGoalList.js
+++ b/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseGoalList/CourseGoalList.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import CourseGoalItem from '../CourseGoalItem/CourseGoalItem';
+import './CourseGoalList.css';
+
+const CourseGoalList = props => {
+  return (
+    <ul className="goal-list">
+      {props.items.map(goal => (
+        <CourseGoalItem
+          key={goal.id}
+          id={goal.id}
+          onDelete={props.onDeleteItem}
+        >
+          {goal.text}
+        </CourseGoalItem>
+      ))}
+    </ul>
+  );
+};
+
+export default CourseGoalList;

--- a/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseInput/CourseInput.js
+++ b/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseInput/CourseInput.js
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+// import styled from 'styled-components';
+
+import Button from '../../UI/Button/Button';
+import styles from './CourseInput.module.css';
+
+// const FormControl = styled.div`
+//       margin: 0.5rem 0;
+
+//     & label {
+//       font-weight: bold;
+//       display: block;
+//       margin-bottom: 0.5rem;
+//       color: ${(props) => (props.invalid ? 'red' : 'black')};
+//     }
+
+//     & input {
+//       display: block;
+//       width: 100%;
+//       border: 1px solid ${(props) => (props.invalid ? '#3f1387' : '#ccc')};
+//       background-color: ${(props) => (props.invalid ? '#ff3366' : '#fad0ec')};
+//       font: inherit;
+//       line-height: 1.5rem;
+//       padding: 0 0.25rem;
+//     }
+
+//     & input:focus {
+//       outline: none;
+//       background: #fad0ec;
+//       border-color: #8b005d;
+//     }
+
+    /* &.invalid input {
+      border-color: #3f1387;  
+      background-color: #ff3366;
+    } */
+
+    /* &.invalid label {
+      color: red;
+    } */
+// `;
+
+const CourseInput = props => {
+  const [enteredValue, setEnteredValue] = useState('');
+  const [isValid, setIsValid] = useState(true);
+
+  const goalInputChangeHandler = event => {
+    if (event.target.value.trim().length > 0) {
+      setIsValid(true);
+    }
+
+    setEnteredValue(event.target.value);
+  };
+
+  const formSubmitHandler = event => {
+    event.preventDefault();
+    if (enteredValue.trim().length === 0) {
+      setIsValid(false);
+      return;
+    }
+    props.onAddGoal(enteredValue);
+  };
+
+  return (
+    <form onSubmit={formSubmitHandler}>
+      <div className={`${styles['form-control']} ${!isValid && styles.invalid}`}>
+        <label>Course Goal</label>
+        <input type="text" onChange={goalInputChangeHandler} />
+      </div>
+      <Button type="submit">Add Goal</Button>
+    </form>
+  );
+};
+
+export default CourseInput;

--- a/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseInput/CourseInput.module.css
+++ b/리액트 파일의 CSS 스타일링/components/CourseGoals/CourseInput/CourseInput.module.css
@@ -1,0 +1,33 @@
+.form-control {
+  margin: 0.5rem 0;
+}
+
+.form-control label {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.form-control input {
+  display: block;
+  width: 100%;
+  border: 1px solid #ccc;
+  font: inherit;
+  line-height: 1.5rem;
+  padding: 0 0.25rem;
+}
+
+.form-control input:focus {
+  outline: none;
+  background: #fad0ec;
+  border-color: #8b005d;
+}
+
+.form-control.invalid input {
+  border-color: #3f1387;  
+  background-color: #ff3366;
+}
+
+.form-control.invalid label {
+  color: red;
+}

--- a/리액트 파일의 CSS 스타일링/components/UI/Button/Button.js
+++ b/리액트 파일의 CSS 스타일링/components/UI/Button/Button.js
@@ -1,0 +1,39 @@
+import React from "react";
+import styles from "./Button.module.css";
+// import styled from 'styled-components';
+
+// const Button = styled.button`
+//     width: 100%;
+//     font: inherit;
+//     padding: 0.5rem 1.5rem;
+//     border: 1px solid #8b005d;
+//     color: white;
+//     background: #8b005d;
+//     box-shadow: 0 0 4px rgba(0, 0, 0, 0.26);
+//     cursor: pointer;
+
+//     @media (min-width: 768px) {
+//     width: auto;
+//   }
+
+//   &:focus {
+//     outline: none;
+//   }
+
+//   &:hover,
+//   &:active {
+//     background: #ac0e77;
+//     border-color: #ac0e77;
+//     box-shadow: 0 0 8px rgba(0, 0, 0, 0.26);
+//   }
+// `;
+
+const Button = props => {
+  return (
+    <button type={props.type} className={styles.button} onClick={props.onClick}>
+      {props.children}
+    </button>
+  );
+};
+
+export default Button;

--- a/리액트 파일의 CSS 스타일링/components/UI/Button/Button.module.css
+++ b/리액트 파일의 CSS 스타일링/components/UI/Button/Button.module.css
@@ -1,0 +1,27 @@
+.button {
+  width: 100%;
+  font: inherit;
+  padding: 0.5rem 1.5rem;
+  border: 1px solid #8b005d;
+  color: white;
+  background: #8b005d;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.26);
+  cursor: pointer;
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button:hover,
+.button:active {
+  background: #ac0e77;
+  border-color: #ac0e77;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.26);
+}
+
+@media (min-width: 768px) {
+  .button {
+    width: auto;
+  }
+}


### PR DESCRIPTION
<리액트 13일차 요약>
🔎 리액트 컴포넌트에 CSS 스타일링을 하는 방법을 다섯 가지로 나눠서 연습해보았습니다.
🔎 해당 웹페이지의 사용자 입력양식과 버튼에 스타일링을 연습했습니다. 
🔎 인라인방식, 동적 클래스를 추가하여 기존 CSS 파일 활용, styled components 패키지 활용, 패키지를 활용하여 동적 props 적용하여 동적 스타일링, CSS 모듈의 사용 방법으로 스타일링을 적용해보았습니다. 🔎 현재 코드는 CSS 모듈을 사용한 상태의 코드상태입니다.
🔎 관련 포스팅: https://itinfogarage.tistory.com/75