### PR TITLE
리액트 19일차 - 음식주문앱 만들면서 복습하기(2)

### DIFF
--- a/리액트 음식주문앱 연습/App.js
+++ b/리액트 음식주문앱 연습/App.js
@@ -1,12 +1,27 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
+import CartModal from "./components/Cart/CartModal";
 import Header from "./components/Layout/Header";
 import Main from "./components/Meals/Main";
 import "./App.css";
 
-function App() {
+function App () {
+  const [modalDisplay, setModalDisplay] = useState(false);
+  const [backdropDisplay, setBackdropDisplay] = useState(false);
+
+  const modalCloseHandler = () => {
+      setModalDisplay(false);
+      setBackdropDisplay(false);
+  }
+
+  const modalOpenHandler = () => {
+      setModalDisplay(true);
+      setBackdropDisplay(true);
+  }
+
   return (
     <Fragment>
-      <Header />
+      <CartModal onModalClose={modalCloseHandler} valueModal={modalDisplay} valueBackdrop={backdropDisplay} />
+      <Header onModalOpen={modalOpenHandler} valueModal={modalDisplay} valueBackdrop={backdropDisplay} />
       <Main />
     </Fragment>
   );

--- a/리액트 음식주문앱 연습/components/Cart/Cart.js
+++ b/리액트 음식주문앱 연습/components/Cart/Cart.js
@@ -1,0 +1,22 @@
+import React from "react";
+import classes from "./Cart.module.css";
+
+const Cart = (props) => {
+    const CartItems = <ul className={classes.cart_list}>{[{ id: 'c1', name: 'Sushi', amount: 2, price: 12.99 }].map((item) => <li>{item.name}</li>)}</ul>;
+
+    return (
+        <div>
+            {CartItems}
+            <div className={classes.cart_info}>
+                <span>Total Amount</span>
+                <span>35.62</span>
+            </div>
+            <div className={classes.cart_btn_box}>
+                <button id={classes.cart_btn_order}>Order</button>
+                <button onClick={props.onModalClose} id={classes.cart_btn_close} >Close</button>
+            </div>
+        </div>
+    );
+}
+
+export default Cart;

--- a/리액트 음식주문앱 연습/components/Cart/Cart.module.css
+++ b/리액트 음식주문앱 연습/components/Cart/Cart.module.css
@@ -1,0 +1,59 @@
+.cart_list {
+    list-style: none;
+    text-align: left;
+    padding-left: 0;
+    margin-top: 0;
+}
+
+.cart_list li {
+    font-size: 1.5rem;
+    font-weight: 500;
+}
+
+.cart_info {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+.cart_info span {
+    font-size: 2rem;
+    font-weight: bold;
+}
+
+.cart_btn_box {
+    text-align: right;
+}
+
+.cart_btn_box button {
+    padding: .8rem 2.5rem;
+    font-size: 1.5rem;
+    border-radius: 30px;
+    cursor: pointer;
+}
+
+#cart_btn_order {
+    margin-right: 20px;
+    background: none;
+    color: var(--color-font-3);
+    border-color: var(--color-box-1);
+    transition: background-color .3s ease;
+}
+
+#cart_btn_order:hover,
+#cart_btn_order:active {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+#cart_btn_close {
+    background-color: var(--color-box-1);
+    color: var(--color-font-1);
+    border-color: var(--color-box-1);
+    transition: background-color .3s ease;
+}
+
+#cart_btn_close:hover,
+#cart_btn_close:active {
+    background-color: var(--color-box-5);
+}

--- a/리액트 음식주문앱 연습/components/Cart/CartModal.js
+++ b/리액트 음식주문앱 연습/components/Cart/CartModal.js
@@ -1,0 +1,16 @@
+import React, { Fragment } from "react";
+import Cart from "./Cart";
+import classes from "./CartModal.module.css";
+
+const CartModal = (props) => {
+    return (
+        <Fragment>
+            {props.valueBackdrop && <div className={`${classes.backdrop} ${props.valueBackdrop ? 'close' : ''}`} onClick={props.onModalClose}></div>}
+            {props.valueModal && <aside className={`${classes.aside} ${props.valueModal ? 'close' : ''}`}>
+                <Cart onModalClose={props.onModalClose}/>
+            </aside>}
+        </Fragment>
+    );
+}
+
+export default CartModal;

--- a/리액트 음식주문앱 연습/components/Cart/CartModal.module.css
+++ b/리액트 음식주문앱 연습/components/Cart/CartModal.module.css
@@ -1,0 +1,44 @@
+.aside {
+    text-align: center;
+    background-color: white;
+    width: 30%;
+    margin: auto;
+    padding: 1rem;
+    position: absolute;
+    z-index: 12;
+    top: 300px;
+    left: 800px;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+    animation: modal-apper .3s ease-out forwards;
+}
+
+.aside.close {
+    display: none;
+}
+
+.backdrop {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    z-index: 11;
+}
+
+.backdrop.close {
+    display: none;
+}
+
+@keyframes modal-apper {
+    from {
+        opacity: 0;
+        transform: translateY(-3rem);
+    }
+
+    to {
+        opacity: 1;
+        transform:  translateY(0);
+    }
+}

--- a/리액트 음식주문앱 연습/components/Layout/Header.js
+++ b/리액트 음식주문앱 연습/components/Layout/Header.js
@@ -3,12 +3,12 @@ import classes from "./Header.module.css";
 import HeaderCartBtn from "./HeaderCartBtn";
 import headerImg from "../../assets/meals.jpg";
 
-const Header = () => {
+const Header = (props) => {
     return (
         <header className={classes.header_section}>
             <div className={classes.header_container}>
                 <h1>React Meals</h1>
-                <HeaderCartBtn />
+                <HeaderCartBtn onModal={props.onModalOpen} valueModal={props.valueModal} valueBackdrop={props.valueBackdrop}/>
             </div>
             <div className={classes.header_img}>
                 <img src={headerImg} alt="header"/>

--- a/리액트 음식주문앱 연습/components/Layout/HeaderCartBtn.js
+++ b/리액트 음식주문앱 연습/components/Layout/HeaderCartBtn.js
@@ -4,7 +4,7 @@ import classes from "./HeaderCartBtn.module.css";
 
 const HeaderCartBtn = (props) => {
     return (
-        <button className={classes.cart_btn}>
+        <button onClick={props.onModal} className={classes.cart_btn}>
             <span className={classes.cart_img}>
                 <CartIcon />
             </span>


### PR DESCRIPTION
<웹페이지 변경사항>
🔎 헤더섹션의 카트버튼을 누르면 담겨있는 메뉴를 확인할 수 있는 오버레이창을 만들었습니다. 오버레이창이 뜨면 주변기능을 사용할 수 없도록 하는 백드랍 요소도 적용했습니다. 🔎 오버레이창은 컨텍스트를 쓰지 않고 최상위 컴포넌트를 거쳐 헤더섹션에 전달하여 띄우는 방식을 사용했습니다. 🔎 관련 포스팅: https://itinfogarage.tistory.com/82