### PR TITLE
리액트 28일차 - 음식 주문 앱에서 주문데이터 저장하기

### DIFF
--- a/음식 주문 앱 주문데이터 저장/Cart/Cart.js
+++ b/음식 주문 앱 주문데이터 저장/Cart/Cart.js
@@ -1,0 +1,101 @@
+import React, { Fragment, useContext, useState } from "react";
+import CartContext from "../../store/cart-context";
+import CartItem from "./CartItem";
+import Checkout from "./Checkout";
+import classes from "./Cart.module.css";
+
+const Cart = (props) => {
+    const [isCheckout, setIsCheckout] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [didSubmit, setDidSubmit] = useState(false);
+
+    const cartCtx = useContext(CartContext);
+
+    const totalAmount = `$${cartCtx.totalAmount.toFixed(2)}`;
+    const hasItems = cartCtx.items.length > 0;
+
+    const cartItemRemoveHandler = (id) => {
+        cartCtx.removeItem(id);
+    }
+
+    const cartItemAddHandler = (item) => {
+        cartCtx.addItem({...item, amount: 1})
+    }
+
+    const orderHandler = () => {
+        setIsCheckout(true);
+    }
+
+    const submitOrderHandler = async (userData) => {
+        setIsSubmitting(true);
+        await fetch('https://react-http-d54e9-default-rtdb.firebaseio.com/Order.json', {
+          method: 'POST',
+          body: JSON.stringify({
+            user: userData,
+            orderedItem: cartCtx.items
+          })
+        });
+        setIsSubmitting(false);
+        setDidSubmit(true);
+        cartCtx.clearCart();
+    }
+
+    const CartItems = (
+      <ul className={classes.cart_list}>
+        {cartCtx.items.map((item) => (
+          <CartItem
+            key={item.id}
+            name={item.name}
+            amount={item.amount}
+            price={item.price}
+            onRemove={cartItemRemoveHandler.bind(null, item.id)}
+            onAdd={cartItemAddHandler.bind(null, item)}
+          />
+        ))}
+      </ul>
+    );
+
+    const modalActions = (
+      <div className={classes.cart_btn_box}>
+        {hasItems && (
+          <button id={classes.cart_btn_order} onClick={orderHandler}>
+            Order
+          </button>
+        )}
+        <button onClick={props.onModalClose} id={classes.cart_btn_close}>
+          Close
+        </button>
+      </div>
+    );
+
+    const cartModalContent = (
+      <Fragment>
+        {CartItems}
+        <div className={classes.cart_info}>
+          <span>Total Amount</span>
+          <span>{totalAmount}</span>
+        </div>
+        {isCheckout && (
+          <Checkout
+            onConfirm={submitOrderHandler}
+            onModalClose={props.onModalClose}
+          />
+        )}
+        {!isCheckout && modalActions}
+      </Fragment>
+    );
+
+    const isSubmittingModalContent = <p>Sending order data...</p>;
+
+    const didSubmitModalContent = <p>Successfully sent the order!</p>;
+
+    return (
+        <div>
+            {!isSubmitting && !didSubmit && cartModalContent}
+            {isSubmitting && isSubmittingModalContent}
+            {!isSubmitting && didSubmit && didSubmitModalContent}
+        </div>
+    );
+}
+
+export default Cart;

--- a/음식 주문 앱 주문데이터 저장/Cart/Checkout.js
+++ b/음식 주문 앱 주문데이터 저장/Cart/Checkout.js
@@ -1,0 +1,85 @@
+import React, { useRef, useState } from "react";
+
+import classes from "./Checkout.module.css";
+
+const isEmpty = (value) => value.trim() === "";
+const isFiveChars = (value) => value.trim().length === 5;
+
+const Checkout = (props) => {
+    const [formInputsValidity, setFormInputsValidity] = useState({
+        name: true,
+        street: true,
+        postalCode: true,
+        city: true
+    });
+
+    const nameInputRef = useRef();
+    const streetInputRef = useRef();
+    const postalInputRef = useRef();
+    const cityInputRef = useRef();
+
+    const submitHandler = (event) => {
+        event.preventDefault();
+
+        const enteredName = nameInputRef.current.value;
+        const enteredStreet = streetInputRef.current.value;
+        const enteredPostal = postalInputRef.current.value;
+        const enteredCity = cityInputRef.current.value;
+
+        const enteredNameIsValid = !isEmpty(enteredName);
+        const enteredStreetIsValid = !isEmpty(enteredStreet);
+        const enteredCityIsValid = !isEmpty(enteredCity);
+        const enteredPostalIsValid = isFiveChars(enteredPostal);
+
+        const formIsValid = enteredNameIsValid && enteredStreetIsValid && enteredCityIsValid && enteredPostalIsValid;
+
+        setFormInputsValidity({
+            name: enteredNameIsValid,
+            street: enteredStreetIsValid,
+            postalCode: enteredPostalIsValid,
+            city: enteredCityIsValid
+        });
+
+        if (!formIsValid) {
+            return;
+        }
+
+        props.onConfirm({
+            name: enteredName,
+            street: enteredStreet,
+            postalCode: enteredPostal,
+            city: enteredCity
+        });
+    }
+
+    return (
+        <form className={classes.form} onSubmit={submitHandler}>
+            <div className={`${classes.control} ${formInputsValidity.name ? '' : classes.invalid}`}>
+                <label htmlFor="name">Your Name</label>
+                <input type="text" id="name" ref={nameInputRef}/>
+                {!formInputsValidity.name && <p>Check your name!</p>}
+            </div>
+            <div className={`${classes.control} ${formInputsValidity.street ? '' : classes.invalid}`}>
+                <label htmlFor="street">Street</label>
+                <input type="text" id="street" ref={streetInputRef}/>
+                {!formInputsValidity.street && <p>Check street name!</p>}
+            </div>
+            <div className={`${classes.control} ${formInputsValidity.postalCode ? '' : classes.invalid}`}>
+                <label htmlFor="postal">Postal code</label>
+                <input type="text" id="postal" ref={postalInputRef}/>
+                {!formInputsValidity.postalCode && <p>Check postalcode! (5 characters long)</p>}
+            </div>
+            <div className={`${classes.control} ${formInputsValidity.city ? '' : classes.invalid}`}>
+                <label htmlFor="city">City</label>
+                <input type="text" id="city" ref={cityInputRef}/>
+                {!formInputsValidity.city && <p>Check your city!</p>}
+            </div>
+            <div className={classes.actions}>
+                <button>Confirm</button>
+                <button type="button" onClick={props.onModalClose}>Cancel</button>
+            </div>
+        </form>
+    );
+}
+
+export default Checkout;

--- a/음식 주문 앱 주문데이터 저장/Cart/Checkout.module.css
+++ b/음식 주문 앱 주문데이터 저장/Cart/Checkout.module.css
@@ -1,0 +1,64 @@
+.form {
+    margin: .5rem 0;
+    height: 16rem;
+    overflow: auto;
+  }
+  
+  .control {
+    margin-bottom: 0.5rem;
+  }
+  
+  .control label {
+    font-weight: bold;
+    margin-bottom: 0.25rem;
+    display: block;
+  }
+  
+  .control input {
+    font: inherit;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    width: 20rem;
+    max-width: 100%;
+  }
+  
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+  }
+  
+  .actions button {
+    font: inherit;
+    color: #5a1a01;
+    cursor: pointer;
+    background-color: transparent;
+    border: none;
+    border-radius: 25px;
+    padding: 0.5rem 2rem; 
+  }
+  
+  .actions button:hover,
+  .actions button:active {
+    background-color: #ffe6dc;
+  }
+  
+  .actions .submit {
+    border: 1px solid #5a1a01;
+    background-color: #5a1a01;
+    color: white;
+  }
+  
+  .actions .submit:hover,
+  .actions .submit:active {
+    background-color: #7a2706;
+  }
+  
+  .invalid label {
+    color: #ca3e51;
+  }
+  
+  .invalid input {
+    border-color: #aa0b20;
+    background-color: #ffeff1;
+  }

--- a/음식 주문 앱 주문데이터 저장/store/CartProvider.js
+++ b/음식 주문 앱 주문데이터 저장/store/CartProvider.js
@@ -1,0 +1,92 @@
+import React, { useReducer } from "react";
+import CartContext from "./cart-context";
+
+const defaultCartState = {
+    items: [],
+    totalAmount: 0
+};
+
+const cartReducer = (state, action) => {
+    if (action.type === 'ADD') {
+        const updatedTotalAmount = state.totalAmount + action.item.price * action.item.amount;
+
+        const existingCartItemIndex = state.items.findIndex((item) => item.id === action.item.id);
+        const existingCartItem = state.items[existingCartItemIndex];
+        
+        let updatedItems;
+
+        if (existingCartItem) {
+            const updatedItem = {
+                ...existingCartItem,
+                amount: existingCartItem.amount + action.item.amount
+            };
+            updatedItems = [...state.items];
+            updatedItems[existingCartItemIndex] = updatedItem;
+       } else {
+           updatedItems = state.items.concat(action.item);
+       }
+
+        return {
+            items: updatedItems,
+            totalAmount: updatedTotalAmount
+        };    
+    }
+
+    if (action.type === 'REMOVE') {
+        const existingCartItemIndex = state.items.findIndex((item) => item.id === action.id);
+        const existingItem = state.items[existingCartItemIndex];
+        const updatedTotalAmount = state.totalAmount - existingItem.price;
+        let updatedItems;
+
+        if (existingItem.amount === 1) {
+            updatedItems = state.items.filter((item) => item.id !== action.id);
+        } else {
+            const updatedItem = {...existingItem, amount: existingItem.amount - 1};
+            updatedItems = [...state.items];
+            updatedItems[existingCartItemIndex] = updatedItem;
+        }
+
+        return {
+            items: updatedItems,
+            totalAmount: updatedTotalAmount
+        };
+    }
+
+    if (action.type === 'CLEAR') {
+        return defaultCartState;
+    }
+
+    return defaultCartState;
+}
+
+const CartProvider = (props) => {
+    const [cartState, dispatchCartAction] = useReducer(cartReducer, defaultCartState);
+
+    const addCartItemHandler = (item) => {
+        dispatchCartAction({type: 'ADD', item: item});
+    }
+
+    const removeCartItemHandler = (id) => {
+        dispatchCartAction({type: 'REMOVE', id: id});
+    }
+
+    const clearCartHandler = () => {
+        dispatchCartAction({type: 'CLEAR'});
+    }
+    
+    const cartContext = {
+        items: cartState.items,
+        totalAmount: cartState.totalAmount,
+        addItem: addCartItemHandler,
+        removeItem: removeCartItemHandler,
+        clearCart: clearCartHandler
+    };
+
+    return (
+        <CartContext.Provider value={cartContext}>
+            {props.children}
+        </CartContext.Provider>
+    );
+} 
+
+export default CartProvider;

--- a/음식 주문 앱 주문데이터 저장/store/cart-context.js
+++ b/음식 주문 앱 주문데이터 저장/store/cart-context.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const CartContext = React.createContext({
+    items: [],
+    totalAmount: 0,
+    addItem: (item) => {},
+    removeItem: (id) => {},
+    clearCart: () => {}
+});
+
+export default CartContext;


### PR DESCRIPTION
<업데이트 내역>
🔎 28일차에는 사용자가 메뉴를 카트에 담아 카트의 order 버튼을 누르면 주문양식이 표출되어 양식을 작성하여 제출하면 백엔드 서버에 주문데이터가 저장되는 과정을 해보았습니다. 🔎 관련 포스팅: https://itinfogarage.tistory.com/101 (블고그 비공개 게시중)